### PR TITLE
Crash fixes

### DIFF
--- a/InkPageIndicator/src/main/java/com/pixelcan/inkpageindicator/InkPageIndicator.java
+++ b/InkPageIndicator/src/main/java/com/pixelcan/inkpageindicator/InkPageIndicator.java
@@ -256,7 +256,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     }
 
     private void resetState() {
-        joiningFractions = new float[pageCount - 1];
+        joiningFractions = new float[pageCount == 0 ? 0 : (pageCount - 1)];
         Arrays.fill(joiningFractions, 0f);
         dotRevealFractions = new float[pageCount];
         Arrays.fill(dotRevealFractions, 0f);
@@ -559,7 +559,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     }
 
     private void setSelectedPage(int now) {
-        if (now == currentPage) return;
+        if (now == currentPage || dotCenterX == null) return;
 
         pageChanging = true;
         previousPage = currentPage;

--- a/InkPageIndicator/src/main/java/com/pixelcan/inkpageindicator/InkPageIndicator.java
+++ b/InkPageIndicator/src/main/java/com/pixelcan/inkpageindicator/InkPageIndicator.java
@@ -559,7 +559,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     }
 
     private void setSelectedPage(int now) {
-        if (now == currentPage || dotCenterX == null) return;
+        if (now == currentPage || dotCenterX == null || dotCenterX.length <= now) return;
 
         pageChanging = true;
         previousPage = currentPage;


### PR DESCRIPTION
1. View throws an exception when view pager adapter is empty. (`java.lang.NegativeArraySizeException`)

2. View throws an exception when it tries to select page after returning from saved instance.

It's just temporary fixes. Does the job for me.